### PR TITLE
fixing encoding error in header-message

### DIFF
--- a/std_msgs/HeaderMsg.cs
+++ b/std_msgs/HeaderMsg.cs
@@ -55,7 +55,7 @@ namespace ROSBridgeLib {
 			}
 			
 			public override string ToYAMLString() {
-				return "{\"seq\" : " + _seq + ", \"stamp\" : " + _stamp.ToYAMLString () + ", frame_id=" + _frame_id + "}";
+				return "{\"seq\": " + _seq + ", \"stamp\": " + _stamp.ToYAMLString () + ", \"frame_id\": \"" + _frame_id + "\"}";
 			}
 		}
 	}


### PR DESCRIPTION
Hi @MathiasCiarlo

I fixed a small bug in the header-message-type. The frame_id field was not properly encoded. 
The following commit fixes the issue.

Best Regards,
Michael